### PR TITLE
fix jsonschemas

### DIFF
--- a/src/schema/json/Dataset.json
+++ b/src/schema/json/Dataset.json
@@ -14,10 +14,11 @@
             "type": "string"
         },
         "identifier": {
-            "description": "A 'business' identifier for the entity, typically as provided by an external system or authority, that persists across implementing systems  (i.e. a  'logical' identifier). Uses a specialized, complex 'Identifier' data type to capture information about the source of the business identifier. ",
-            "items": {
+          "description": "A 'business' identifier for the entity, typically as provided by an external system or authority, that persists across implementing systems  (i.e. a  'logical' identifier). Uses a specialized, complex 'Identifier' data type to capture information about the source of the business identifier. ",
+          "items": {
             "$ref": "https://example.org/cda-data-model/definitions/Identifier"
-            }
+          },
+	  "type" : "array"
         },
         "conformsTo": {
             "description": "An established standard to which the described resource conforms; for CDA, https://github.com/CancerDataAggregator/cda-data-model. Maps to dcat:conformsTo.",

--- a/src/schema/json/Patient.json
+++ b/src/schema/json/Patient.json
@@ -33,12 +33,10 @@
         "research_subject_list": {
             "description": "A list of ResearchSubject identities for this Patient.  We could keep a list of the Projects but the ResearchSubject mimics the use of case_id in existing data.  All relevant data for each Project will be in the ResearchSubject.",
             "items": {
-                "research_subject_id": {
-                    "oneOf" : [
-                        {"$ref": "https://example.org/cda-data-model/ResearchSubject.json"},
+              "oneOf" : [
+                        {"$ref": "https://example.org/cda-data-model/ResearchSubject"},
                         {"type": "string"}
                     ]
-                }
             },
             "type": "array"
         },

--- a/src/schema/json/Project.json
+++ b/src/schema/json/Project.json
@@ -47,28 +47,11 @@
             "type": "string"
         },
         "studies": {
-            "description": "List of studies associated with this Project. For POC, using this model instead of Identifier due to confusion over type CodeableConcept; reconsider for MVP.",
-            "properties": {
-                "label": {
-                    "description": "Human-readable name of the Study",
-                    "type": "string"
-                },
-                "system": {
-                    "description": "The system or namespace that defines the Study.",
-                    "type": "string"                    },
-                "value": {
-                    "description": "The value of the identifier, as defined by the system.",
-                    "type": "string"                    },
-                "embargo_date": {
-                    "description": "The date on which publication and release of data is permitted.  This data is made available with the condition that it cannot be published or disseminated before this date.  The field is represented as a string in this format: CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm].",
-                    "type": "string"
-                },
-                "dbgap_accession": {
-                    "description": "The link to the dbgap accession record for data associated with this Study. For MVP, will model this as a string, but this could be modeled as an external reference.",
-                    "type": "string"
-                }
-            },
-            "type": "array"
+          "description": "List of studies associated with this Project. For POC, using this model instead of Identifier due to confusion over type CodeableConcept; reconsider for MVP.",
+	  "items": {
+	    "$ref":"https://example.org/cda-data-model/definitions/Study"
+          },
+          "type": "array"
         },
         "dct:title": {
             "description": "Official project name. Maps to dct:title.",

--- a/src/schema/json/ResearchSubject.json
+++ b/src/schema/json/ResearchSubject.json
@@ -26,7 +26,7 @@
         "associated_project": {
             "description": "A reference to the Project(s) of which this ResearchSubject is a member. The associated_project may be embedded using the $ref definition or may be a reference to the id for the Project - or a URI expressed as a string to an existing entity.",
             "oneOf" : [
-                {"$ref": "https://example.org/cda-data-model/Project.json"},
+                {"$ref": "https://example.org/cda-data-model/Project"},
                 {"type": "string"}
             ]
         },

--- a/src/schema/json/definitions.json
+++ b/src/schema/json/definitions.json
@@ -89,6 +89,35 @@
             "title": "Quantity",
             "type": "object"
         },
+        "Study": {
+ 	    "type":"object",
+ 	  "description": "Representing 'study' concept from different sources.",
+	    "additionalProperties": false,
+	    "title":"Study",
+    	    "required": [
+	        "label",
+	        "system",
+	        "value"
+	    ],
+            "properties": {
+                "label": {
+                    "description": "Human-readable name of the Study",
+                    "type": "string"
+                },
+                "system": {
+                    "description": "The system or namespace that defines the Study.",
+                    "type": "string"                    },
+                "value": {
+                    "description": "The value of the identifier, as defined by the system.",
+                    "type": "string"                    },
+                "embargo_date": {
+                    "description": "The date on which publication and release of data is permitted.  This data is made available with the condition that it cannot be published or disseminated before this date.  The field is represented as a string in this format: CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm].",
+                    "type": "string"
+                },
+                "dbgap_accession": {
+                    "description": "The link to the dbgap accession record for data associated with this Study. For MVP, will model this as a string, but this could be modeled as an external reference.",
+                    "type": "string"
+                }}},
         "ExternalReference": {
             "additionalProperties": false,
             "description": "An external reference to an ontology, vocabulary or other system",


### PR DESCRIPTION
and rationalize some items...
Walking through the diff
* added "array" type to the "identifier" key in Dataset, which had an "items" specifier
* removed the "research_subject_id" key that was wrapping the "oneOf" specifier for items of "research_subject_list" in Patient (maybe the thought was to have a research_subject_id as one of the oneOf elements?)
* in Project.json, make the study object consistent with other entity type definitions
  * factor out the object type under the "studies" property into its own definition ("Study")
  * put that definition in definitions.json and make the "studies" property accept an array of $ref:https://.../Study entities
* Regularize $ref urls - take out ".json" extensions there.
